### PR TITLE
Change auto TTL output to be in seconds

### DIFF
--- a/PowerShell/DNSExport.ps1
+++ b/PowerShell/DNSExport.ps1
@@ -503,7 +503,7 @@ If ($AllDomains -eq $true){
                         Priority = $Record.priority
                         Proxiable = $Record.proxiable
                         Proxied = $Record.proxied
-                        TTL = $Record.ttl
+                        TTL = if ($Record.ttl -eq "1"){"3600"}else{$Record.ttl}
                         Comment = $Record.comment
                         }
                         # Output records to .csv file, appending records to file rather than overwriting.


### PR DESCRIPTION
Fixes #32 - Changes auto config to be in seconds (by default 1 hour).